### PR TITLE
Add support for index-path and pages-index-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A GitHub action to turn a GitHub project into a self-hosted Helm chart repo, usi
 - `mark_as_latest`: When you set this to `false`, it will mark the created GitHub release not as 'latest'.
 - `packages_with_index`: When you set this to `true`, it will upload chart packages directly into publishing branch.
 - `pages_branch`: Name of the branch to be used to push the index and artifacts. (default to: gh-pages but it is not set in the action it is a default value for the chart-releaser binary)
+- `pages_index_path`: Path to the index file in the gh-pages branch. (default to: index.yaml but it is not set in the action)
+- `index_path`: Path to the index file. (default to: .cr-index/index.yaml but it is not set in the action)
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,12 @@ inputs:
   pages_branch:
     description: "Name of the branch to be used to push the index and artifacts. (default to: gh-pages but it is not set in the action it is a default value for the chart-releaser binary)"
     required: false
+  pages_index_path:
+    description: "The GitHub pages index path. (default to: index.yaml but it is not set in the action)"
+    required: false
+  index_path:
+    description: "Path to index file. (default to: .cr-index/index.yaml but it is not set in the action)"
+    required: false
 outputs:
   changed_charts:
     description: "A comma-separated list of charts that were released on this run. Will be an empty string if no updates were detected, will be unset if `--skip_packaging` is used: in the latter case your custom packaging step is responsible for setting its own outputs if you need them."
@@ -118,6 +124,14 @@ runs:
 
         if [[ -n "${{ inputs.pages_branch }}" ]]; then
             args+=(--pages-branch "${{ inputs.pages_branch }}")
+        fi
+
+        if [[ -n "${{ inputs.pages_index_path }}" ]]; then
+            args+=(--pages-index-path "${{ inputs.pages_index_path }}")
+        fi
+
+        if [[ -n "${{ inputs.index_path }}" ]]; then
+            args+=(--index-path "${{ inputs.index_path }}")
         fi
 
         "$GITHUB_ACTION_PATH/cr.sh" "${args[@]}"

--- a/cr.sh
+++ b/cr.sh
@@ -55,6 +55,8 @@ main() {
   local mark_as_latest=true
   local packages_with_index=false
   local pages_branch=
+  local index_path=
+  local pages_index_path=
 
   parse_command_line "$@"
 
@@ -173,6 +175,18 @@ parse_command_line() {
     --pages-branch)
       if [[ -n "${2:-}" ]]; then
         pages_branch="$2"
+        shift
+      fi
+      ;;
+    --index-path)
+      if [[ -n "${2:-}" ]]; then
+        index_path="$2"
+        shift
+      fi
+      ;;
+    --pages-index-path)
+      if [[ -n "${2:-}" ]]; then
+        pages_index_path="$2"
         shift
       fi
       ;;
@@ -350,6 +364,12 @@ update_index() {
   fi
   if [[ -n "$pages_branch" ]]; then
     args+=(--pages-branch "$pages_branch")
+  fi
+  if [[ -n "$index_path" ]]; then
+    args+=(--index-path "$index_path")
+  fi
+  if [[ -n "$pages_index_path" ]]; then
+    args+=(--pages-index-path "$pages_index_path")
   fi
 
   echo 'Updating charts repo index...'

--- a/cr.sh
+++ b/cr.sh
@@ -38,6 +38,8 @@ Usage: $(basename "$0") <options>
         --skip-upload             Skip package upload, just create the release. Not needed in case of OCI upload.
     -l, --mark-as-latest          Mark the created GitHub release as 'latest' (default: true)
         --packages-with-index     Upload chart packages directly into publishing branch
+        --index-path              The path to the index file
+        --pages-index-path        The path to the index file in the pages branch
 EOF
 }
 


### PR DESCRIPTION
As mentioned in the [issue](https://github.com/helm/chart-releaser-action/issues/183), it seems no way to customize `index-path` and `pages-index-path` in current chart-releaser-action.

What I want to achieve is that chart-releaser-action reads and updates `index.yaml` in a sub folder like `docs/static/index.yaml` instead of project root. The `docs/` may be a nodejs sub project aiming to generate static site to `gh-pages` branch.

Due to the original repo maintainer's slow response for [PR 184](https://github.com/helm/chart-releaser-action/pull/184), I've decided to merge and release this change in my own repo.